### PR TITLE
Make 6502 decompress_faster_v2.asm (& v1) 3-4% faster at the cost of 1 byte extra.

### DIFF
--- a/asm/6502/decompress_faster_v2.asm
+++ b/asm/6502/decompress_faster_v2.asm
@@ -7,7 +7,7 @@
 ;
 ; This code is written for the ACME assembler.
 ;
-; The code is 240 bytes for the small version, and 255 bytes for the normal.
+; The code is 241 bytes for the small version, and 256 bytes for the normal.
 ;
 ; Copyright John Brandwood 2021.
 ;
@@ -66,7 +66,6 @@ LZSA_DST_HI     =       $FF
 ;
 ; Args: lzsa_srcptr = ptr to compessed data
 ; Args: lzsa_dstptr = ptr to output buffer
-; Uses: lots!
 ;
 
 DECOMPRESS_LZSA2_FAST:
@@ -101,34 +100,28 @@ lzsa2_unpack:   ldx     #$00                    ; Hi-byte of length or offset.
                 lsr
                 lsr
                 cmp     #$03                    ; Extended length?
-                bcc     .inc_cp_len
+                bcc     .cp_got_len
 
-                inx
-                jsr     .get_length             ; X=1 for literals, returns CC.
+                jsr     .get_length             ; X=0 for literals, returns CC.
+                stx     .cp_npages + 1          ; Hi-byte of length.
 
-                ora     #0                      ; Check the lo-byte of length
-                beq     .put_cp_len             ; without effecting CC.
+.cp_got_len:    tax                             ; Lo-byte of length.
 
-.inc_cp_len:    inx                             ; Increment # of pages to copy.
-
-.put_cp_len:    stx     <lzsa_length
-                tax
-
-.cp_page:       lda     (lzsa_srcptr),y         ; CC throughout the execution of
+.cp_byte:       lda     (lzsa_srcptr),y         ; CC throughout the execution of
                 sta     (lzsa_dstptr),y         ; of this .cp_page loop.
-
                 inc     <lzsa_srcptr + 0
                 bne     .cp_skip1
                 inc     <lzsa_srcptr + 1
-
 .cp_skip1:      inc     <lzsa_dstptr + 0
                 bne     .cp_skip2
                 inc     <lzsa_dstptr + 1
-
 .cp_skip2:      dex
-                bne     .cp_page
-                dec     <lzsa_length            ; Any full pages left to copy?
-                bne     .cp_page
+                bne     .cp_byte
+.cp_npages:     lda     #0                      ; Any full pages left to copy?
+                beq     .lz_offset
+
+                dec     .cp_npages + 1          ; Unlikely, so can be slow.
+                bcc     .cp_byte                ; Always true!
 
                 ;
                 ; Copy bytes from decompressed window.
@@ -193,7 +186,7 @@ lzsa2_unpack:   ldx     #$00                    ; Hi-byte of length or offset.
 .set_offset:    stx     <lzsa_offset + 1        ; Save new offset.
                 sta     <lzsa_offset + 0
 
-.lz_length:     ldx     #$00                    ; Hi-byte of length.
+.lz_length:     ldx     #1                      ; Hi-byte of length+256.
 
                 lda     <lzsa_cmdbuf
                 and     #$07
@@ -202,15 +195,13 @@ lzsa2_unpack:   ldx     #$00                    ; Hi-byte of length or offset.
                 cmp     #$09                    ; Extended length?
                 bcc     .got_lz_len
 
-                jsr     .get_length             ; X=0 for match, returns CC.
+                jsr     .get_length             ; X=1 for match, returns CC.
+                inx                             ; Hi-byte of length+256.
 
 .got_lz_len:    eor     #$FF                    ; Negate the lo-byte of length
                 tay                             ; and check for zero.
                 iny
-                beq     .get_lz_win
                 eor     #$FF
-
-                inx                             ; Increment # of pages to copy.
 
 .get_lz_dst:    adc     <lzsa_dstptr + 0        ; Calc address of partial page.
                 sta     <lzsa_dstptr + 0        ; Always CC from previous CMP.
@@ -218,33 +209,34 @@ lzsa2_unpack:   ldx     #$00                    ; Hi-byte of length or offset.
                 dec     <lzsa_dstptr + 1
 
 .get_lz_win:    clc                             ; Calc address of match.
-                lda     <lzsa_dstptr + 0        ; N.B. Offset is negative!
-                adc     <lzsa_offset + 0
+                adc     <lzsa_offset + 0        ; N.B. Offset is negative!
                 sta     <lzsa_winptr + 0
                 lda     <lzsa_dstptr + 1
                 adc     <lzsa_offset + 1
                 sta     <lzsa_winptr + 1
 
-.lz_page:       lda     (lzsa_winptr),y
+.lz_byte:       lda     (lzsa_winptr),y
                 sta     (lzsa_dstptr),y
                 iny
-                bne     .lz_page
-                inc     <lzsa_winptr + 1
+                bne     .lz_byte
                 inc     <lzsa_dstptr + 1
                 dex                             ; Any full pages left to copy?
-                bne     .lz_page
+                bne     .lz_more
 
                 jmp     .cp_length              ; Loop around to the beginning.
+
+.lz_more:       inc     <lzsa_winptr + 1        ; Unlikely, so can be slow.
+                bne     .lz_byte                ; Always true!
 
                 ;
                 ; Lookup tables to differentiate literal and match lengths.
                 ;
 
-.nibl_len_tbl:  !byte   9                       ; 2+7 (for match).
-                !byte   3                       ; 0+3 (for literal).
+.nibl_len_tbl:  !byte   3                       ; 0+3 (for literal).
+                !byte   9                       ; 2+7 (for match).
 
-.byte_len_tbl:  !byte   24 - 1                  ; 2+7+15 - CS (for match).
-                !byte   18 - 1                  ; 0+3+15 - CS (for literal).
+.byte_len_tbl:  !byte   18 - 1                  ; 0+3+15 - CS (for literal).
+                !byte   24 - 1                  ; 2+7+15 - CS (for match).
 
                 ;
                 ; Get 16-bit length in X:A register pair, return with CC.
@@ -263,13 +255,15 @@ lzsa2_unpack:   ldx     #$00                    ; Hi-byte of length or offset.
                 bcc     .got_length
                 beq     .finished
 
-.word_length:   jsr     .get_byte               ; So rare, this can be slow!
+.word_length:   clc                             ; MUST return CC!
+                jsr     .get_byte               ; So rare, this can be slow!
                 pha
                 jsr     .get_byte               ; So rare, this can be slow!
                 tax
                 pla
-                clc                             ; MUST return CC!
-                rts
+                bne     .got_word               ; Check for zero lo-byte.
+                dex                             ; Do one less page loop if so.
+.got_word:      rts
 
 .get_byte:      lda     (lzsa_srcptr),y         ; Subroutine version for when
                 inc     <lzsa_srcptr + 0        ; inlining isn't advantageous.


### PR DESCRIPTION
Hi there!

I reorganized my 6502 "decompress_faster" LZSA1 & LZSA2 decompressors to optimize for lengths < 256 bytes, and this has sped them up by 3-4% at the cost of 1 extra byte of code.

They both use self-modifying code now, but that could be removed (at a small % cost) if you wanted.

BTW ... thank you for the Salvador compressor! Its high speed compression makes the ZX0 format actually usable.

If you are interested, I can give you the links to my ZX0 decompressors for the 6502 and HuC6280.

Best wishes,

John

